### PR TITLE
action: add actions to build zip for both chromium and firefox

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,36 +1,48 @@
-name: Build and Release CRX
+name: Build and Release Extension
 
 on:
   push:
     tags:
-      - 'v*' 
+      - 'v*'
   workflow_dispatch: # The manual button
 
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
-      contents: write 
-    
+      contents: write
+
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 0 # Important for tagging
+          fetch-depth: 0
 
-      - name: Set up Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-
-      - name: Install CRX utility
-        run: npm install -g crx
-
-      - name: Build CRX
+      - name: Build Chrome ZIP
         run: |
-          echo "${{ secrets.CHROME_PRIVATE_KEY }}" > private.pem
-          crx pack . -p private.pem -o extension.crx
-          rm private.pem
+          zip -r chrome.zip . \
+            -x ".git/*" \
+            -x ".github/*" \
+            -x "docs/*" \
+            -x "scripts/*" \
+            -x "_metadata/*" \
+            -x "manifest.firefox.json" \
+            -x "build.sh" \
+            -x "README.md" \
+            -x ".gitignore"
+
+      - name: Build Firefox ZIP
+        run: |
+          cp manifest.firefox.json manifest.json
+          zip -r firefox.zip . \
+            -x ".git/*" \
+            -x ".github/*" \
+            -x "docs/*" \
+            -x "scripts/*" \
+            -x "_metadata/*" \
+            -x "build.sh" \
+            -x "README.md" \
+            -x ".gitignore"
 
       - name: Generate Tag Name
         id: tagger
@@ -39,13 +51,15 @@ jobs:
           if [[ "${{ github.ref_type }}" == "tag" ]]; then
             echo "tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=manual-$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
+            echo "tag=$(date +'%Y%m%d-%H%M%S')" >> $GITHUB_OUTPUT
           fi
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: extension.crx
+          files: |
+            chrome.zip
+            firefox.zip
           tag_name: ${{ steps.tagger.outputs.tag }}
           name: Release ${{ steps.tagger.outputs.tag }}
           draft: false

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+# Build script for 北科大 SSO+
+# Usage:
+#   ./build.sh chrome   - Package for Chrome
+#   ./build.sh firefox  - Package for Firefox
+#   ./build.sh both     - Package for both
+
+set -e
+
+EXCLUDE_PATTERNS=(".git/*" ".github/*" "_metadata/*" "manifest.firefox.json" "build.sh" "*.zip" "docs/*")
+EXCLUDE_ARGS=""
+for pattern in "${EXCLUDE_PATTERNS[@]}"; do
+  EXCLUDE_ARGS="$EXCLUDE_ARGS -x \"$pattern\""
+done
+
+build_chrome() {
+  echo "Building for Chrome..."
+  eval zip -r chrome.zip . $EXCLUDE_ARGS
+  echo "Created chrome.zip"
+}
+
+build_firefox() {
+  echo "Building for Firefox..."
+  cp manifest.json manifest.chrome.bak
+  cp manifest.firefox.json manifest.json
+  eval zip -r firefox.zip . $EXCLUDE_ARGS
+  mv manifest.chrome.bak manifest.json
+  echo "Created firefox.zip"
+}
+
+case "${1:-both}" in
+  chrome)  build_chrome ;;
+  firefox) build_firefox ;;
+  both)    build_chrome; build_firefox ;;
+  *)       echo "Usage: $0 {chrome|firefox|both}"; exit 1 ;;
+esac

--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -1,0 +1,76 @@
+{
+  "manifest_version": 3,
+  "name": "北科大 SSO+",
+  "version": "26.3.13",
+  "browser_specific_settings": {
+    "gecko": {
+      "id": "ntut-sso-plus@ntut-npc",
+      "strict_min_version": "113.0"
+    }
+  },
+  "permissions": [
+    "storage",
+    "declarativeNetRequest",
+    "downloads",
+    "tabs"
+  ],
+  "host_permissions": [
+    "https://app.ntut.edu.tw/*",
+    "https://istream.ntut.edu.tw/*",
+    "https://istudy.ntut.edu.tw/*"
+  ],
+  "background": {
+    "scripts": [
+      "iSchoolPlus/iSchoolPlusBackgroundServiceWorker.js"
+    ]
+  },
+  "declarative_net_request": {
+    "rule_resources": [
+      {
+        "id": "ruleset_1",
+        "enabled": true,
+        "path": "rules.json"
+      }
+    ]
+  },
+  "content_scripts": [
+    {
+      "matches": [
+        "https://istream.ntut.edu.tw/*",
+        "https://istudy.ntut.edu.tw/*"
+      ],
+      "js": [
+        "iSchoolPlus/iSchoolPlusVideoDownloadUI.js"
+      ],
+      "css": [
+        "iSchoolPlus/iSchoolPlusVideoDownloadUI.css"
+      ],
+      "all_frames": true,
+      "run_at": "document_idle"
+    },
+    {
+      "matches": [
+        "https://istudy.ntut.edu.tw/*"
+      ],
+      "js": [
+        "iSchoolPlus/iSchoolPlusFileDownloadUI.js"
+      ],
+      "css": [
+        "iSchoolPlus/iSchoolPlusFileDownloadUI.css"
+      ],
+      "all_frames": true,
+      "run_at": "document_idle"
+    }
+  ],
+  "action": {
+    "default_popup": "popup.html"
+  },
+  "icons": {
+    "16": "icons/icon16.png",
+    "32": "icons/icon32.png",
+    "48": "icons/icon48.png",
+    "128": "icons/icon128.png"
+  },
+  "homepage_url": "https://github.com/NTUT-NPC/ntut_sso_plus",
+  "description": "提供北科學生免密碼與免驗證碼快速存取校內系統的瀏覽器擴充功能。"
+}


### PR DESCRIPTION
This pull request updates the build and release process for the browser extension to support packaging and releasing both Chrome and Firefox versions. The GitHub Actions workflow and related scripts have been reworked to simplify multi-browser packaging, and a new Firefox manifest has been added.

**Build & Release Process Improvements:**

* The GitHub Actions workflow `.github/workflows/build.yml` was updated to build and release both Chrome and Firefox ZIP packages instead of just a CRX for Chrome. The workflow now creates `chrome.zip` and `firefox.zip` and uploads both as release assets, removing the previous CRX packaging and related Node.js setup steps. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L1-R1) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L19-R45) [[3]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L42-R62)
* A new `build.sh` script was added to automate packaging for Chrome, Firefox, or both, handling manifest swapping and file exclusions.

**Firefox Support:**

* A new `manifest.firefox.json` was introduced to provide Firefox-specific extension metadata and configuration, enabling proper packaging and compatibility with Firefox.