### PR TITLE
feat: add user-specific CSS features

### DIFF
--- a/entrypoints/popup/components/ExperimentalTab.vue
+++ b/entrypoints/popup/components/ExperimentalTab.vue
@@ -1,36 +1,57 @@
 <script setup lang="ts">
-import { ref, onMounted } from 'vue';
+import { ref, onMounted, toRaw } from 'vue';
+import { browser } from 'wxt/browser';
 import { startSSO } from '../sso';
 import CollapsibleGuide from './CollapsibleGuide.vue';
 import FileDownloadPreview from './FileDownloadPreview.vue';
 import CourseSelectorPreview from './CourseSelectorPreview.vue';
 import VideoDownloadPreview from './VideoDownloadPreview.vue';
+import ToggleSwitch from './ToggleSwitch.vue';
 
 defineProps<{
   isLoggedIn?: boolean;
 }>();
 
-const themes = [
-  { name: '淺色', value: 'light' },
-  { name: '深色', value: 'dark' },
-];
-
+const isDarkMode = ref(false);
 const debugMode = ref(false);
+const userCssSettings = ref<Record<string, boolean>>({ global: true });
+const subdomains = ref<string[]>([]);
 
 onMounted(async () => {
-  const data = await browser.storage.local.get('debugMode');
+  const data = await browser.storage.local.get(['debugMode', 'userCssSettings', 'theme']) as { debugMode?: boolean, userCssSettings?: Record<string, boolean>, theme?: string };
   debugMode.value = !!data.debugMode;
+  isDarkMode.value = data.theme === 'dark';
+  console.log('[ExperimentalTab] Loading settings from storage:', data.userCssSettings);
+  if (data.userCssSettings) {
+    userCssSettings.value = { ...data.userCssSettings };
+  } else {
+    // Initialize with default if absolutely empty
+    userCssSettings.value = { global: true };
+    await browser.storage.local.set({ userCssSettings: { global: true } });
+  }
+
+  // Discover subdomains with CSS files
+  const cssModules = import.meta.glob('../../user-css/*.css', { eager: true });
+  console.log('[ExperimentalTab] Discovered CSS modules:', cssModules);
+  subdomains.value = Object.keys(cssModules).map(path => 
+    path.split('/').pop()!.replace('.css', '')
+  );
 });
 
-const toggleDebugMode = async () => {
-  const newValue = !debugMode.value;
-  debugMode.value = newValue;
-  await browser.storage.local.set({ debugMode: newValue });
+const saveSettings = async () => {
+  const rawData = toRaw(userCssSettings.value);
+  console.log('[ExperimentalTab] Saving userCssSettings:', rawData);
+  await browser.storage.local.set({ userCssSettings: rawData });
 };
 
-const changeTheme = async (theme: string) => {
-  document.body.setAttribute('data-theme', theme);
-  await browser.storage.local.set({ theme });
+const toggleDebugMode = async () => {
+  await browser.storage.local.set({ debugMode: debugMode.value });
+};
+
+const toggleDarkMode = async () => {
+  const newTheme = isDarkMode.value ? 'dark' : 'light';
+  document.body.setAttribute('data-theme', newTheme);
+  await browser.storage.local.set({ theme: newTheme });
 };
 
 const handleSSO = (code: string) => {
@@ -42,17 +63,36 @@ const handleSSO = (code: string) => {
   <div class="exp-section animate-fade-in">
     <div class="glass-card exp-card">
       <div class="exp-card-body">
-        <div class="category-title">配色主題</div>
-        <div class="exp-card-desc">選擇您喜愛的介面配色方案。</div>
-        <div class="exp-card-actions">
-          <button 
-            v-for="theme in themes" 
-            :key="theme.value" 
-            class="modern-btn" 
-            @click="changeTheme(theme.value)"
-          >
-            {{ theme.name }}
-          </button>
+        <div class="category-title">擴充功能樣式</div>
+        <div class="exp-card-desc">切換深色模式以獲得更舒適的夜間使用體驗。</div>
+        <ToggleSwitch 
+          v-model="isDarkMode"
+          label="深色模式"
+          description="啟用深色背景與明亮文字的配色方案。"
+          @update:modelValue="toggleDarkMode"
+        />
+      </div>
+    </div>
+
+    <div class="glass-card exp-card">
+      <div class="exp-card-body">
+        <div class="category-title">網站特製樣式</div>
+        <div class="exp-card-desc">管理各子網域的樣式。若要套用變更，請重新整理網頁。</div>
+        <div class="toggle-list">
+          <ToggleSwitch 
+            v-model="userCssSettings.global"
+            label="全域樣式"
+            description="關閉後將停用所有子網域的自訂 CSS 樣式。"
+            @update:modelValue="saveSettings"
+          />
+          <ToggleSwitch 
+            v-for="sub in subdomains" 
+            :key="sub"
+            v-model="userCssSettings[sub]"
+            :label="`${sub} 樣式`"
+            description="切換該子網域的特定樣式。"
+            @update:modelValue="saveSettings"
+          />
         </div>
       </div>
     </div>
@@ -141,11 +181,12 @@ const handleSSO = (code: string) => {
       <div class="exp-card-body">
         <div class="category-title">偵錯模式</div>
         <div class="exp-card-desc">開啟後可在 console 查看 JSON。</div>
-        <div class="exp-card-actions">
-          <button class="modern-btn" @click="toggleDebugMode">
-            {{ debugMode ? '關閉' : '開啟' }} Debug mode
-          </button>
-        </div>
+        <ToggleSwitch 
+          v-model="debugMode"
+          label="Debug Mode"
+          description="記錄詳細的 API 請求與響應資訊到開發者主控台。"
+          @update:modelValue="toggleDebugMode"
+        />
       </div>
     </div>
   </div>
@@ -217,8 +258,9 @@ const handleSSO = (code: string) => {
     }
 }
 
-.theme-btn {
-    padding: 6px 12px;
-    font-size: 12px;
+.toggle-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--spacing-sm);
 }
 </style>

--- a/entrypoints/popup/components/ToggleSwitch.vue
+++ b/entrypoints/popup/components/ToggleSwitch.vue
@@ -1,0 +1,109 @@
+<script setup lang="ts">
+const props = defineProps<{
+  modelValue: boolean;
+  label?: string;
+  description?: string;
+}>();
+
+const emit = defineEmits<{
+  (e: 'update:modelValue', value: boolean): void;
+}>();
+
+const toggle = () => {
+  emit('update:modelValue', !props.modelValue);
+};
+</script>
+
+<template>
+  <div class="toggle-container" @click="toggle" :class="{ 'is-active': modelValue }">
+    <div class="toggle-info" v-if="label || description">
+      <div v-if="label" class="toggle-label">{{ label }}</div>
+      <div v-if="description" class="toggle-description">{{ description }}</div>
+    </div>
+    <div class="toggle-track">
+      <div class="toggle-thumb"></div>
+    </div>
+  </div>
+</template>
+
+<style scoped>
+.toggle-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--spacing-md);
+  padding: 10px 14px;
+  background: var(--bg-main);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  cursor: pointer;
+  transition: all var(--transition-normal);
+  user-select: none;
+  min-height: 56px;
+}
+
+.toggle-container:hover {
+  border-color: var(--primary);
+  background: var(--bg-hover, rgba(0, 0, 0, 0.02));
+}
+
+body[data-theme="dark"] .toggle-container:hover {
+  background: rgba(255, 255, 255, 0.03);
+}
+
+.toggle-info {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  flex: 1;
+}
+
+.toggle-label {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-main);
+}
+
+.toggle-description {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.3;
+}
+
+.toggle-track {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: var(--border);
+  border-radius: 11px;
+  transition: all var(--transition-normal);
+  flex-shrink: 0;
+}
+
+.toggle-thumb {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 18px;
+  height: 18px;
+  background: white;
+  border-radius: 50%;
+  transition: all var(--transition-normal);
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+}
+
+.toggle-container.is-active .toggle-track {
+  background: var(--accent);
+}
+
+/* Light mode primary for active state if accent is too subtle */
+body:not([data-theme="dark"]) .toggle-container.is-active .toggle-track {
+  background: var(--primary);
+}
+
+.toggle-container.is-active .toggle-thumb {
+  transform: translateX(18px);
+}
+
+/* GNOME/iOS feel: thumb slightly larger on active is often nice, but let's keep it simple first */
+</style>

--- a/entrypoints/user-css.content.ts
+++ b/entrypoints/user-css.content.ts
@@ -1,0 +1,138 @@
+// Auto-discover all CSS files in user-css/ folder at build time.
+// Filename = subdomain, e.g. nportal.css → nportal.ntut.edu.tw
+//
+// Per-section path matching via @match at-rule:
+//   @match "/index.do";
+//   body { color: red; }
+//
+//   @match "/login.do";
+//   body { color: blue; }
+//
+// CSS before any @match applies to ALL pages on that subdomain.
+// Supports * wildcard, e.g. @match "/course/*";
+const cssModules = import.meta.glob('./user-css/*.css', { query: '?raw', eager: true });
+
+interface CssSection {
+    pattern: string | null;  // null = global (no @match)
+    css: string;
+}
+
+function parseSections(raw: string): CssSection[] {
+    const sections: CssSection[] = [];
+    const matchRe = /@match\s+"(.+?)"\s*;/g;
+    let lastIndex = 0;
+    let m;
+
+    while ((m = matchRe.exec(raw)) !== null) {
+        // CSS before this @match (global or belongs to previous section)
+        const before = raw.slice(lastIndex, m.index).trim();
+        if (before) {
+            // If no section exists yet, this is global CSS
+            if (sections.length === 0) {
+                sections.push({ pattern: null, css: before });
+            } else {
+                // Append to previous section
+                sections[sections.length - 1].css += '\n' + before;
+            }
+        }
+        // Start new section for this @match
+        sections.push({ pattern: m[1], css: '' });
+        lastIndex = m.index + m[0].length;
+    }
+
+    // Remaining CSS after last @match
+    const remaining = raw.slice(lastIndex).trim();
+    if (remaining) {
+        if (sections.length === 0) {
+            sections.push({ pattern: null, css: remaining });
+        } else {
+            sections[sections.length - 1].css += '\n' + remaining;
+        }
+    }
+
+    return sections;
+}
+
+const CSS_MAP: Record<string, CssSection[]> = {};
+for (const [path, mod] of Object.entries(cssModules)) {
+    const filename = path.split('/').pop()!.replace('.css', '');
+    const raw = (mod as { default: string }).default;
+    CSS_MAP[filename] = parseSections(raw);
+}
+
+function pathMatches(pathname: string, pattern: string): boolean {
+    const escaped = pattern.replace(/[.+^${}()|[\]\\]/g, '\\$&').replace(/\*/g, '.*');
+    return new RegExp('^' + escaped + '$').test(pathname);
+}
+
+export default defineContentScript({
+    matches: ['https://*.ntut.edu.tw/*'],
+    allFrames: true,
+    matchAboutBlank: true,
+    runAt: 'document_start',
+    main() {
+        const hostname = window.location.hostname;
+        const subdomain = hostname.replace('.ntut.edu.tw', '');
+        const sections = CSS_MAP[subdomain];
+
+        // 1. Inject CSS
+        if (sections) {
+            const pathname = window.location.pathname;
+            const matched = sections
+                .filter((s) => s.pattern === null || pathMatches(pathname, s.pattern))
+                .map((s) => s.css)
+                .join('\n');
+
+            if (matched.trim()) {
+                const style = document.createElement('style');
+                style.id = 'ntut-sso-user-css';
+                style.textContent = matched;
+                (document.head || document.documentElement).appendChild(style);
+            }
+        }
+
+        // 2. Enable Autocomplete (ONLY for muid/password and add hints for Bitwarden)
+        function enableAutocomplete() {
+            // Target specific fields: Username (muid, username) and Password
+            const usernameSelector = 'input[name="muid"], input#muid, input[name="username"]';
+            const passwordSelector = 'input[type="password"]';
+
+            // Handle Username
+            const usernameFields = document.querySelectorAll(usernameSelector);
+            usernameFields.forEach((el) => {
+                if (el.getAttribute('autocomplete') === 'off') {
+                    el.removeAttribute('autocomplete');
+                }
+                if (!el.getAttribute('autocomplete')) {
+                    el.setAttribute('autocomplete', 'username');
+                }
+            });
+
+            // Handle Password
+            const passwordFields = document.querySelectorAll(passwordSelector);
+            passwordFields.forEach((el) => {
+                if (el.getAttribute('autocomplete') === 'off' || el.getAttribute('autocomplete') === 'new-password') {
+                    el.removeAttribute('autocomplete');
+                }
+                if (!el.getAttribute('autocomplete')) {
+                    el.setAttribute('autocomplete', 'current-password');
+                }
+            });
+        }
+
+        // Run immediately and periodically/on changes
+        enableAutocomplete();
+        const observer = new MutationObserver(enableAutocomplete);
+        observer.observe(document.documentElement, {
+            childList: true,
+            subtree: true,
+            attributes: true,
+            attributeFilter: ['autocomplete'],
+        });
+
+        // Some sites re-add it in their own scripts, so we check a few times
+        for (let delay of [500, 1000, 2000, 5000]) {
+            setTimeout(enableAutocomplete, delay);
+        }
+    },
+});

--- a/entrypoints/user-css.content.ts
+++ b/entrypoints/user-css.content.ts
@@ -10,6 +10,8 @@
 //
 // CSS before any @match applies to ALL pages on that subdomain.
 // Supports * wildcard, e.g. @match "/course/*";
+import { browser } from 'wxt/browser';
+
 const cssModules = import.meta.glob('./user-css/*.css', { query: '?raw', eager: true });
 
 interface CssSection {
@@ -70,26 +72,55 @@ export default defineContentScript({
     allFrames: true,
     matchAboutBlank: true,
     runAt: 'document_start',
-    main() {
+    async main() {
         const hostname = window.location.hostname;
         const subdomain = hostname.replace('.ntut.edu.tw', '');
         const sections = CSS_MAP[subdomain];
 
-        // 1. Inject CSS
-        if (sections) {
-            const pathname = window.location.pathname;
-            const matched = sections
-                .filter((s) => s.pattern === null || pathMatches(pathname, s.pattern))
-                .map((s) => s.css)
-                .join('\n');
+        const updateCss = async () => {
+            const { userCssSettings } = await browser.storage.local.get('userCssSettings') as { userCssSettings?: Record<string, boolean> };
+            const settings = userCssSettings ?? { global: true }; // Default to global: true if not set
 
-            if (matched.trim()) {
-                const style = document.createElement('style');
-                style.id = 'ntut-sso-user-css';
-                style.textContent = matched;
-                (document.head || document.documentElement).appendChild(style);
+            // Check if global or subdomain is disabled
+            // If settings for a subdomain aren't set, default to true
+            const isGlobalEnabled = settings.global !== false;
+            const isSubdomainEnabled = settings[subdomain] !== false;
+
+            if (!isGlobalEnabled || !isSubdomainEnabled) {
+                document.getElementById('ntut-sso-user-css')?.remove();
+                return;
             }
-        }
+
+            if (sections) {
+                const pathname = window.location.pathname;
+                const matched = sections
+                    .filter((s) => s.pattern === null || pathMatches(pathname, s.pattern))
+                    .map((s) => s.css)
+                    .join('\n');
+
+                if (matched.trim()) {
+                    let style = document.getElementById('ntut-sso-user-css') as HTMLStyleElement;
+                    if (!style) {
+                        style = document.createElement('style');
+                        style.id = 'ntut-sso-user-css';
+                        (document.head || document.documentElement).appendChild(style);
+                    }
+                    style.textContent = matched;
+                } else {
+                    document.getElementById('ntut-sso-user-css')?.remove();
+                }
+            }
+        };
+
+        // 1. Inject CSS
+        await updateCss();
+
+        // Listen for storage changes to dynamic update CSS
+        browser.storage.onChanged.addListener((changes) => {
+            if (changes.userCssSettings) {
+                updateCss();
+            }
+        });
 
         // 2. Enable Autocomplete (ONLY for muid/password and add hints for Bitwarden)
         function enableAutocomplete() {

--- a/entrypoints/user-css.content.ts
+++ b/entrypoints/user-css.content.ts
@@ -92,11 +92,8 @@ export default defineContentScript({
             }
 
             if (sections) {
-                const pathname = window.location.pathname;
-                const matched = sections
-                    .filter((s) => s.pattern === null || pathMatches(pathname, s.pattern))
-                    .map((s) => s.css)
-                    .join('\n');
+                // Apply all CSS sections, ignore @match
+                const matched = sections.map((s) => s.css).join('\n');
 
                 if (matched.trim()) {
                     let style = document.getElementById('ntut-sso-user-css') as HTMLStyleElement;

--- a/entrypoints/user-css/nportal.css
+++ b/entrypoints/user-css/nportal.css
@@ -7,9 +7,6 @@
    Supports * wildcard, e.g. @match "/course/*";
    CSS before any @match applies to ALL pages on this subdomain.
    ============================================================ */
-
-@match "/index.do";
-
 :root {
     transition: all 0.5s ease-in-out !important;
 }
@@ -58,7 +55,7 @@ table[style="border:0; width:100%;"] {
 }
 
 /* 主登入框 */
-.boxContent {
+#wrap > .boxContent {
     margin: auto !important;
     background-color: #ffffff;
     padding: 2rem;
@@ -79,7 +76,7 @@ img[src="template/ntut/index/images/l_login_title01.png"] {
     display: none !important;
 }
 
-.boxContent::before {
+.wrap > .boxContent::before {
     content: "登入校園入口";
     display: block;
     font-size: 1.5rem;
@@ -148,4 +145,171 @@ img[src="template/ntut/index/images/l_login_title01.png"] {
     margin-top: 0.5rem !important;
 }
 
-@match "/login.do";
+#header {
+    background: transparent !important;
+    min-height: 33px !important;
+    height: 66px !important;
+    position: relative !important;
+    .headerArea {
+        background: transparent !important;
+    }
+}
+
+.navigation {
+    display: flex !important;
+    align-items: center;
+    justify-content: center;
+    position: absolute !important;
+    top: 0 !important;
+}
+
+.tab ul::before {
+    display: none !important;
+}
+
+.tab ul {
+    flex-wrap: wrap !important;
+    overflow-x: scroll;
+    width: 100% !important;
+    padding: 0 1rem !important;
+    display: flex !important;
+    align-items: center;
+}
+
+.tab ul a {
+    border-radius: 3rem;
+    color: #fff !important;
+}
+
+.tab ul a:hover {
+    background-color: #fff !important;
+    color: #13438d !important;
+}
+
+div[class="tab clearfix"] {
+    width: 100% !important;
+    display: flex !important;
+    background-color: #13438d !important;
+    overflow-y: hidden;
+    padding: 0rem !important;
+    /* border-radius: 0 0 2rem 2rem !important; */
+    /* margin: 0 2rem !important; */
+    height: 66px !important;
+}
+
+
+.headerLogo, .statist {
+    display: none !important;
+}
+
+.eipBoxTitle {
+    background: #fff !important;
+    color: #000 !important;
+    display: block !important;
+}
+
+.eipBoxTitle img {
+    display: block !important;
+    position: absolute !important;
+    top: 16.5px !important;
+    left: 18px !important;
+    width: calc(50px/2) !important;
+    height: calc(45px/2) !important;
+}
+
+div[style="width:70px; position:absolute; top:7px; right:5px;"] {
+    display: none !important;
+}
+
+#mainContainer {
+    background-color: #c3c3c311;
+}
+
+.boxOuter {
+    border-radius: 2rem !important;
+    overflow: hidden !important;
+    background: #fff !important;
+}
+
+.boxHeader,
+.eipBoxTitle {
+    cursor: pointer;
+}
+
+.mainTitle a {
+    color: #000;
+}
+
+a[href="javascript:efolderMain()"] {
+    display: none !important;
+}
+
+#Column1, #Column2, #Column3 {
+    min-height: 0;
+    padding: 0 !important;
+    width: calc(100% - 1rem) !important;
+    padding: .5rem !important;
+    margin: auto !important;
+}
+
+/* Debugging */
+/* #Column1 {
+    background-color: rgb(255, 227, 227) !important;
+}
+
+#Column2 {
+    background-color: rgb(233, 255, 227) !important;
+}
+
+#Column3 {
+    background-color: rgb(227, 238, 255) !important;
+} */
+
+
+#div_aptreeContent {
+    max-height: 100% !important;
+}
+
+.aptree {
+    background-color: transparent;
+}
+
+.aptree a {
+    color: #000 !important;
+}
+
+.aptree img {
+    display: none !important;
+}
+
+.aptree > ul {
+    display: grid !important;
+    grid-template-columns: repeat(auto-fit, minmax(266px, 1fr));
+    gap: 1rem;           /* Space between icons */
+    padding: 1rem;
+    list-style: none;    /* Remove bullet points */
+    margin: 0;
+}
+
+.aptree > ul > li {
+    background: rgba(200, 230, 255, 0.6);
+    border: 1px solid rgba(255, 255, 255, 0.3);
+    padding: 20px;
+    border-radius: 12px;
+    text-align: left; /* 改成靠左，像卡片一樣 */
+    transition: 0.3s;
+    overflow-wrap: break-word; /* 長文字換行 */
+}
+
+.aptree > ul > li:hover {
+    background: #fff;
+    transform: translateY(-5px);
+    box-shadow: 0 10px 20px rgba(0,0,0,0.05);
+}
+
+div[style="text-align:right; font-size:.9rem;"] {
+    padding-right: 1rem;
+    a {
+        color: #000 !important;
+    }
+}

--- a/entrypoints/user-css/nportal.css
+++ b/entrypoints/user-css/nportal.css
@@ -1,0 +1,151 @@
+/* ============================================================
+   北科大 SSO+ — User CSS for nportal.ntut.edu.tw
+   ============================================================
+   Filename determines the subdomain: nportal.css → nportal.ntut.edu.tw
+
+   Use @match to restrict styles to specific paths.
+   Supports * wildcard, e.g. @match "/course/*";
+   CSS before any @match applies to ALL pages on this subdomain.
+   ============================================================ */
+
+@match "/index.do";
+
+:root {
+    transition: all 0.5s ease-in-out !important;
+}
+
+/* 背景灰色長方形 */
+body {
+    background: none !important;
+}
+
+form[name="login"] {
+    width: 100%;
+    height: 100%;
+    margin: 0;
+    background-color: #f2f2f2;
+}
+
+/* 左上角的北科大 Logo */
+.header {
+    display: none !important;
+}
+
+/* 下面 */
+.copyright {
+    display: none !important;
+}
+
+/* 忘記密碼 */
+table[style="border:0; width:100%;"] {
+    display: none !important;
+}
+
+#sliderShow {
+    display: none !important;
+}
+
+#wrap {
+    background: none !important;
+    width: 100% !important;
+    height: 100% !important;
+    margin: 0 !important;
+    position: static !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    align-items: center !important;
+}
+
+/* 主登入框 */
+.boxContent {
+    margin: auto !important;
+    background-color: #ffffff;
+    padding: 2rem;
+    border-radius: 1rem;
+    color: rgb(0, 0, 0) !important;
+    width: auto !important;
+    height: auto !important;
+    display: flex !important;
+    flex-direction: column !important;
+    justify-content: center !important;
+    align-items: center !important;
+    box-shadow: 0 0 10px rgba(0, 0, 0, 0.1) !important;
+    border-radius: 2rem !important;
+    overflow: hidden !important;
+}
+
+img[src="template/ntut/index/images/l_login_title01.png"] {
+    display: none !important;
+}
+
+.boxContent::before {
+    content: "登入校園入口";
+    display: block;
+    font-size: 1.5rem;
+    font-weight: bold;
+    margin-bottom: 1rem;
+    text-align: center;
+}
+
+.form {
+    height: auto !important;
+    max-width: 500px !important;
+    width: 100% !important;
+}
+
+.co {
+    height: auto !important;
+    margin: 0 !important;
+    width: 100% !important;
+    margin-bottom: 1rem !important;
+}
+
+.title {
+    color: #000000 !important;
+    width: 100% !important;
+    margin: 0% !important;
+    text-align: left !important;
+    font-size: 1rem !important;
+}
+
+.co>input {
+    width: 100% !important;
+    font-size: 1rem !important;
+    line-height: 2rem !important;
+    padding: 1rem !important;
+    height: 3rem !important;
+    box-sizing: border-box !important;
+    border-radius: 2rem !important;
+    margin-top: 0.5rem !important;
+}
+
+.titleEng {
+    display: none !important;
+}
+
+#authImage {
+    margin-top: 0.5rem !important;
+}
+
+#authcode {
+    text-transform: uppercase;
+}
+
+#eyes {
+    display: none !important;
+}
+
+.loginBtn {
+    width: 100% !important;
+    margin: 0 !important;
+}
+
+.loginBtn>input {
+    width: 100% !important;
+    height: 3rem !important;
+    border-radius: 2rem !important;
+    margin-top: 0.5rem !important;
+}
+
+@match "/login.do";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntut_sso_plus",
-  "version": "26.68.0",
+  "version": "26.69.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntut_sso_plus",
-      "version": "26.68.0",
+      "version": "26.69.0",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntut_sso_plus",
-  "version": "26.68.0",
+  "version": "26.69.0",
   "description": "北科大 SSO+ 提供統一且便捷的介面，讓北科學生快速登入校內各項服務，並提供課程教材下載功能。",
   "main": "popup.js",
   "directories": {

--- a/wxt.config.ts
+++ b/wxt.config.ts
@@ -17,12 +17,7 @@ export default defineConfig({
             'tabs',
         ],
         host_permissions: [
-            'https://app.ntut.edu.tw/*',
-            'https://istream.ntut.edu.tw/*',
-            'https://istudy.ntut.edu.tw/*',
-            'https://aps-course.ntut.edu.tw/*',
-            'https://aps-sign1.ntut.edu.tw/*',
-            'https://isms-nagios.ntut.edu.tw/*',
+            'https://*.ntut.edu.tw/*',
         ],
         homepage_url: 'https://github.com/NTUT-NPC/ntut_sso_plus',
         icons: {


### PR DESCRIPTION
This pull request introduces a new user CSS system for NTUT SSO+, allowing per-subdomain and per-section styling, and improves login form usability by enabling autocomplete. The changes include a new content script for user CSS injection and autocomplete, a sample CSS file for the `nportal.ntut.edu.tw` subdomain, and a simplification of host permissions in the extension configuration.

User CSS system and injection:

* Added `entrypoints/user-css.content.ts` to auto-discover CSS files in the `user-css/` folder, parse per-section `@match` rules, and inject CSS based on the current subdomain and path. This enables flexible, user-defined styling for NTUT web portals.
* Created `entrypoints/user-css/nportal.css` as a sample user CSS file, demonstrating per-path styling using `@match` rules and providing improved UI for the login page on `nportal.ntut.edu.tw`.

Login form usability improvements:

* The content script enables autocomplete for username and password fields, removes restrictive attributes, and adds hints for password managers like Bitwarden. It runs immediately and observes DOM changes to ensure persistent improvements.

Extension configuration update:

* Simplified host permissions in `wxt.config.ts` to use a wildcard for all NTUT subdomains, reducing maintenance and allowing broader coverage for the content script.