### PR TITLE
feat: inject script to enable native pdf.js download functionality

### DIFF
--- a/entrypoints/pdf-viewer.content.ts
+++ b/entrypoints/pdf-viewer.content.ts
@@ -1,0 +1,56 @@
+export default defineContentScript({
+    matches: ['https://istudy.ntut.edu.tw/*'],
+    runAt: 'document_start',
+    allFrames: true,
+    matchAboutBlank: true,
+    world: 'MAIN',
+    main() {
+        // 1. Force Download variable to 1
+        function lockDownload() {
+            try {
+                if (!(window as any).__ntut_sso_locked) {
+                    Object.defineProperty(window, 'Download', { get: () => 1, configurable: false });
+                    (window as any).__ntut_sso_locked = true;
+                }
+            } catch (e) {
+                (window as any).Download = 1;
+            }
+        }
+
+        // 2. Intercept document.write to patch the variable in dynamic frames
+        const originalWrite = Document.prototype.write;
+        Document.prototype.write = function (this: Document, ...args: any[]) {
+            const patchedArgs = args.map(arg => {
+                if (typeof arg === 'string' && arg.includes('Download')) {
+                    return arg.replace(/Download\s*=\s*0/g, 'Download=1');
+                }
+                return arg;
+            });
+            return originalWrite.apply(this, patchedArgs as any);
+        };
+
+        // 3. Unhide the native download and print buttons
+        function unhide() {
+            const selectors = ['#download', '#print', '#secondaryDownload', '#secondaryPrint'];
+            selectors.forEach(s => {
+                const el = document.querySelector(s) as HTMLElement;
+                if (el) {
+                    el.style.setProperty('display', 'inline-block', 'important');
+                    el.style.setProperty('visibility', 'visible', 'important');
+                    el.classList.remove('hiddenMediumView', 'hiddenSmallView', 'hiddenLargeView', 'hidden');
+                }
+            });
+        }
+
+        // Run immediately and periodically for a few seconds
+        lockDownload();
+        let count = 0;
+        const interval = setInterval(() => {
+            lockDownload();
+            unhide();
+            if (++count > 20) clearInterval(interval);
+        }, 500);
+
+        new MutationObserver(unhide).observe(document.documentElement, { childList: true, subtree: true });
+    },
+});

--- a/entrypoints/pdf-viewer.content.ts
+++ b/entrypoints/pdf-viewer.content.ts
@@ -5,83 +5,11 @@ export default defineContentScript({
     matchAboutBlank: true,
     world: 'MAIN',
     main() {
-        /**
-         * NTUT iStudy PDF Restrictions Bypass
-         * 
-         * [CONTEXT]
-         * iStudy disables native PDF.js features (Download/Print) by forcing the global 
-         * `Download` variable to 0. It also hides the UI buttons via CSS.
-         * 
-         * [STRATEGY]
-         * To restore these features safely, we implement a multi-layered bypass:
-         * 1. Context Guard  : Prevents logic leakage to non-viewer pages.
-         * 2. Property Lock : Traps 'Download' assignments using Getters/Setters.
-         * 3. HTML Patching : Intercepts document.write for dynamic iframe content.
-         * 4. CSS Injection  : Forces button visibility with zero runtime overhead.
-         */
-
-        function isPdfJsViewerUrl(urlString: string): boolean {
-            try {
-                const url = new URL(urlString);
-                const path = url.pathname.toLowerCase();
-                const search = url.search.toLowerCase();
-                const hash = url.hash.toLowerCase();
-                return (
-                    path.endsWith('/viewer.html') ||
-                    path.includes('/viewer.html') ||
-                    path.includes('/pdf.js/') ||
-                    search.includes('file=') ||
-                    hash.includes('file=')
-                );
-            } catch {
-                return false;
-            }
-        }
-
-        function isPdfJsViewerContext(): boolean {
-            if (isPdfJsViewerUrl(window.location.href)) {
-                return true;
-            }
-            if (window.location.href === 'about:blank') {
-                try {
-                    if (window.parent && window.parent !== window && isPdfJsViewerUrl(window.parent.location.href)) {
-                        return true;
-                    }
-                } catch { }
-                try {
-                    if (window.top && window.top !== window && isPdfJsViewerUrl(window.top.location.href)) {
-                        return true;
-                    }
-                } catch { }
-            }
-            return false;
-        }
-
-        // STEP 1: RESTRICT EXECUTION CONTEXT
-        // We only want to patch the PDF viewer. Running this on normal iStudy pages
-        // might break unrelated functionality (like the SSO login itself).
-        if (!isPdfJsViewerContext()) {
-            return;
-        }
-
-        // STEP 2: GLOBAL VARIABLE LOCK
-        // We use a Getter/Setter trap on 'window.Download'.
-        // - Getter: Always returns 1, overriding any page-level assignments.
-        // - Setter: An empty function that "swallows" assignments.
-        //   Crucial for preventing TypeErrors in strict-mode scripts when they try 
-        //   to run 'Download = 0'.
+        // 1. Force Download variable to 1
         function lockDownload() {
             try {
                 if (!(window as any).__ntut_sso_locked) {
-                    Object.defineProperty(window, 'Download', {
-                        get: () => 1,
-                        set: () => {
-                            // Swallow assignments to prevent the page from disabling features
-                            // and to prevent crashes in strict-mode scripts.
-                        },
-                        configurable: true,
-                        enumerable: true,
-                    });
+                    Object.defineProperty(window, 'Download', { get: () => 1, configurable: false });
                     (window as any).__ntut_sso_locked = true;
                 }
             } catch (e) {
@@ -89,10 +17,7 @@ export default defineContentScript({
             }
         }
 
-        // STEP 3: DYNAMIC HTML INTERCEPTION
-        // Some frames are built dynamically using document.write(). By the time 
-        // our script runs, the HTML might already contain hardcoded '<script>Download=0</script>'.
-        // We patch 'write' to perform a regex "search-and-replace" on the incoming HTML stream.
+        // 2. Intercept document.write to patch the variable in dynamic frames
         const originalWrite = Document.prototype.write;
         Document.prototype.write = function (this: Document, ...args: any[]) {
             const patchedArgs = args.map(arg => {
@@ -104,30 +29,28 @@ export default defineContentScript({
             return originalWrite.apply(this, patchedArgs as any);
         };
 
-        // STEP 4: UI VISIBILITY ENFORCEMENT (CSS INJECTION)
-        // We inject a style block once. This is more efficient than a MutationObserver
-        // because the browser handles the visibility natively for all current and 
-        // future elements, with zero JavaScript overhead.
-        const style = document.createElement('style');
-        style.textContent = `
-            #download, #print, #secondaryDownload, #secondaryPrint {
-                display: inline-block !important;
-                visibility: visible !important;
-            }
-            /* Override iStudy's responsive hiding classes */
-            .hiddenMediumView, .hiddenSmallView, .hiddenLargeView, .hidden {
-                display: inline-block !important;
-                visibility: visible !important;
-            }
-        `;
-        (document.head || document.documentElement).appendChild(style);
+        // 3. Unhide the native download and print buttons
+        function unhide() {
+            const selectors = ['#download', '#print', '#secondaryDownload', '#secondaryPrint'];
+            selectors.forEach(s => {
+                const el = document.querySelector(s) as HTMLElement;
+                if (el) {
+                    el.style.setProperty('display', 'inline-block', 'important');
+                    el.style.setProperty('visibility', 'visible', 'important');
+                    el.classList.remove('hiddenMediumView', 'hiddenSmallView', 'hiddenLargeView', 'hidden');
+                }
+            });
+        }
 
-        // Run immediately and periodically for a few seconds to ensure variable lock
+        // Run immediately and periodically for a few seconds
         lockDownload();
         let count = 0;
         const interval = setInterval(() => {
             lockDownload();
+            unhide();
             if (++count > 20) clearInterval(interval);
         }, 500);
+
+        new MutationObserver(unhide).observe(document.documentElement, { childList: true, subtree: true });
     },
 });

--- a/entrypoints/pdf-viewer.content.ts
+++ b/entrypoints/pdf-viewer.content.ts
@@ -5,11 +5,83 @@ export default defineContentScript({
     matchAboutBlank: true,
     world: 'MAIN',
     main() {
-        // 1. Force Download variable to 1
+        /**
+         * NTUT iStudy PDF Restrictions Bypass
+         * 
+         * [CONTEXT]
+         * iStudy disables native PDF.js features (Download/Print) by forcing the global 
+         * `Download` variable to 0. It also hides the UI buttons via CSS.
+         * 
+         * [STRATEGY]
+         * To restore these features safely, we implement a multi-layered bypass:
+         * 1. Context Guard  : Prevents logic leakage to non-viewer pages.
+         * 2. Property Lock : Traps 'Download' assignments using Getters/Setters.
+         * 3. HTML Patching : Intercepts document.write for dynamic iframe content.
+         * 4. CSS Injection  : Forces button visibility with zero runtime overhead.
+         */
+
+        function isPdfJsViewerUrl(urlString: string): boolean {
+            try {
+                const url = new URL(urlString);
+                const path = url.pathname.toLowerCase();
+                const search = url.search.toLowerCase();
+                const hash = url.hash.toLowerCase();
+                return (
+                    path.endsWith('/viewer.html') ||
+                    path.includes('/viewer.html') ||
+                    path.includes('/pdf.js/') ||
+                    search.includes('file=') ||
+                    hash.includes('file=')
+                );
+            } catch {
+                return false;
+            }
+        }
+
+        function isPdfJsViewerContext(): boolean {
+            if (isPdfJsViewerUrl(window.location.href)) {
+                return true;
+            }
+            if (window.location.href === 'about:blank') {
+                try {
+                    if (window.parent && window.parent !== window && isPdfJsViewerUrl(window.parent.location.href)) {
+                        return true;
+                    }
+                } catch { }
+                try {
+                    if (window.top && window.top !== window && isPdfJsViewerUrl(window.top.location.href)) {
+                        return true;
+                    }
+                } catch { }
+            }
+            return false;
+        }
+
+        // STEP 1: RESTRICT EXECUTION CONTEXT
+        // We only want to patch the PDF viewer. Running this on normal iStudy pages
+        // might break unrelated functionality (like the SSO login itself).
+        if (!isPdfJsViewerContext()) {
+            return;
+        }
+
+        // STEP 2: GLOBAL VARIABLE LOCK
+        // We use a Getter/Setter trap on 'window.Download'.
+        // - Getter: Always returns 1, overriding any page-level assignments.
+        // - Setter: An empty function that "swallows" assignments.
+        //   Crucial for preventing TypeErrors in strict-mode scripts when they try 
+        //   to run 'Download = 0'.
         function lockDownload() {
             try {
                 if (!(window as any).__ntut_sso_locked) {
-                    Object.defineProperty(window, 'Download', { get: () => 1, configurable: false });
+                    Object.defineProperty(window, 'Download', {
+                        get: () => 1,
+                        set: () => {
+                            // Swallow assignments to prevent the page from disabling features
+                            // and to prevent crashes in strict-mode scripts.
+                        },
+                        configurable: true,
+                        enumerable: true,
+                    });
                     (window as any).__ntut_sso_locked = true;
                 }
             } catch (e) {
@@ -17,7 +89,10 @@ export default defineContentScript({
             }
         }
 
-        // 2. Intercept document.write to patch the variable in dynamic frames
+        // STEP 3: DYNAMIC HTML INTERCEPTION
+        // Some frames are built dynamically using document.write(). By the time 
+        // our script runs, the HTML might already contain hardcoded '<script>Download=0</script>'.
+        // We patch 'write' to perform a regex "search-and-replace" on the incoming HTML stream.
         const originalWrite = Document.prototype.write;
         Document.prototype.write = function (this: Document, ...args: any[]) {
             const patchedArgs = args.map(arg => {
@@ -29,28 +104,30 @@ export default defineContentScript({
             return originalWrite.apply(this, patchedArgs as any);
         };
 
-        // 3. Unhide the native download and print buttons
-        function unhide() {
-            const selectors = ['#download', '#print', '#secondaryDownload', '#secondaryPrint'];
-            selectors.forEach(s => {
-                const el = document.querySelector(s) as HTMLElement;
-                if (el) {
-                    el.style.setProperty('display', 'inline-block', 'important');
-                    el.style.setProperty('visibility', 'visible', 'important');
-                    el.classList.remove('hiddenMediumView', 'hiddenSmallView', 'hiddenLargeView', 'hidden');
-                }
-            });
-        }
+        // STEP 4: UI VISIBILITY ENFORCEMENT (CSS INJECTION)
+        // We inject a style block once. This is more efficient than a MutationObserver
+        // because the browser handles the visibility natively for all current and 
+        // future elements, with zero JavaScript overhead.
+        const style = document.createElement('style');
+        style.textContent = `
+            #download, #print, #secondaryDownload, #secondaryPrint {
+                display: inline-block !important;
+                visibility: visible !important;
+            }
+            /* Override iStudy's responsive hiding classes */
+            .hiddenMediumView, .hiddenSmallView, .hiddenLargeView, .hidden {
+                display: inline-block !important;
+                visibility: visible !important;
+            }
+        `;
+        (document.head || document.documentElement).appendChild(style);
 
-        // Run immediately and periodically for a few seconds
+        // Run immediately and periodically for a few seconds to ensure variable lock
         lockDownload();
         let count = 0;
         const interval = setInterval(() => {
             lockDownload();
-            unhide();
             if (++count > 20) clearInterval(interval);
         }, 500);
-
-        new MutationObserver(unhide).observe(document.documentElement, { childList: true, subtree: true });
     },
 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ntut_sso_plus",
-  "version": "26.73.0",
+  "version": "26.74.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "ntut_sso_plus",
-      "version": "26.73.0",
+      "version": "26.74.0",
       "hasInstallScript": true,
       "license": "ISC",
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ntut_sso_plus",
-  "version": "26.73.0",
+  "version": "26.74.0",
   "description": "北科大 SSO+ 提供統一且便捷的介面，讓北科學生快速登入校內各項服務，並提供課程教材下載功能。",
   "main": "popup.js",
   "directories": {


### PR DESCRIPTION
This pull request introduces a new content script for the `pdf-viewer` that enhances user access to download and print features on the `istudy.ntut.edu.tw` website. The script ensures the download functionality is always enabled and makes the native download and print buttons visible, even if the site tries to hide or disable them.

Key changes:

**Feature enablement and patching:**
* Adds a content script (`pdf-viewer.content.ts`) that forces the `Download` variable to always be `1`, overriding any site attempts to disable downloads.
* Intercepts `document.write` calls to patch dynamically injected content so that any instance of `Download=0` is replaced with `Download=1`.

**UI improvements:**
* Unhides the native download and print buttons by modifying their CSS properties and removing classes that hide them, ensuring they remain accessible to users.
* Uses a `MutationObserver` and periodic checks to repeatedly enforce these changes, handling dynamic updates to the page.